### PR TITLE
Making client-id error message more usable

### DIFF
--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -25,4 +25,9 @@
     <string name="sign_out">Sign out</string>
     <string name="welcome">Welcome to the Live SDK for Android Sample Application!</string>
     <string name="begin">Begin by hitting in the \"Sign in\" button.</string>
+    <string name="AndroidSignInHelpLink">http://go.microsoft.com/fwlink/p/?LinkId=193157</string>
+    <string name="unset_client_message_title">Unset Client ID</string>
+    <string name="unset_client_message_body">In order to use the sample, you must first place your client id in com.microsoft.live.sample.Config.CLIENT_ID. For more information click navigate, or paste the link from the clipboard.</string>
+    <string name="unset_client_message_positive">Navigate</string>
+    <string name="unset_client_message_negitive">Cancel</string>
 </resources>

--- a/sample/src/com/microsoft/live/sample/SignInActivity.java
+++ b/sample/src/com/microsoft/live/sample/SignInActivity.java
@@ -5,17 +5,19 @@
 package com.microsoft.live.sample;
 
 import java.util.Arrays;
-
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.text.ClipboardManager;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import com.microsoft.live.LiveAuthClient;
 import com.microsoft.live.LiveAuthException;
 import com.microsoft.live.LiveAuthListener;
@@ -25,9 +27,13 @@ import com.microsoft.live.LiveStatus;
 
 public class SignInActivity extends Activity {
     private LiveSdkSampleApplication mApp;
+
     private LiveAuthClient mAuthClient;
+
     private ProgressDialog mInitializeDialog;
+
     private Button mSignInButton;
+
     private TextView mBeginTextView;
 
     @Override
@@ -35,43 +41,62 @@ public class SignInActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.signin);
 
-        mApp = (LiveSdkSampleApplication) getApplication();
+        mApp = (LiveSdkSampleApplication)getApplication();
         mAuthClient = new LiveAuthClient(mApp, Config.CLIENT_ID);
         mApp.setAuthClient(mAuthClient);
 
         mInitializeDialog = ProgressDialog.show(this, "", "Initializing. Please wait...", true);
 
-        mBeginTextView = (TextView) findViewById(R.id.beginTextView);
-        mSignInButton = (Button) findViewById(R.id.signInButton);
-        
+        mBeginTextView = (TextView)findViewById(R.id.beginTextView);
+        mSignInButton = (Button)findViewById(R.id.signInButton);
+
         // Check to see if the CLIENT_ID has been changed.
         if (Config.CLIENT_ID.equals("YOUR CLIENT ID HERE")) {
+            final Activity thisActivity = this;
             mSignInButton.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    showToast("In order to use the sample, you must first place your client id " + 
-                              "in com.microsoft.live.sample.Config.CLIENT_ID. For more " +
-                              "information see http://go.microsoft.com/fwlink/?LinkId=397523");
+                    final String AndroidSignInHelpLink = getString(R.string.AndroidSignInHelpLink);
+                    ClipboardManager clipBoard = (ClipboardManager)thisActivity.getSystemService(CLIPBOARD_SERVICE);
+                    clipBoard.setText(AndroidSignInHelpLink);
+
+                    AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(thisActivity);
+                    AlertDialog dialog = dialogBuilder
+                            .setTitle(R.string.unset_client_message_title)
+                            .setMessage(R.string.unset_client_message_body)
+                            .setPositiveButton(R.string.unset_client_message_positive,
+                                    new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            final Intent intent = new Intent(Intent.ACTION_VIEW);
+                                            intent.setData(Uri.parse(AndroidSignInHelpLink));
+                                            startActivity(intent);
+                                        }
+                                    })
+                            .setNegativeButton(R.string.unset_client_message_negitive,
+                                    new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            dialog.cancel();
+                                        }
+                                    }).create();
+                    dialog.show();
                 }
             });
         } else {
             mSignInButton.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mAuthClient.login(SignInActivity.this,
-                                      Arrays.asList(Config.SCOPES),
-                                      new LiveAuthListener() {
+                    mAuthClient.login(SignInActivity.this, Arrays.asList(Config.SCOPES), new LiveAuthListener() {
                         @Override
-                        public void onAuthComplete(LiveStatus status,
-                                                   LiveConnectSession session,
-                                                   Object userState) {
+                        public void onAuthComplete(LiveStatus status, LiveConnectSession session, Object userState) {
                             if (status == LiveStatus.CONNECTED) {
                                 launchMainActivity(session);
                             } else {
                                 showToast("Login did not connect. Status is " + status + ".");
                             }
                         }
-    
+
                         @Override
                         public void onAuthError(LiveAuthException exception, Object userState) {
                             showToast(exception.getMessage());
@@ -95,9 +120,7 @@ public class SignInActivity extends Activity {
             }
 
             @Override
-            public void onAuthComplete(LiveStatus status,
-                                       LiveConnectSession session,
-                                       Object userState) {
+            public void onAuthComplete(LiveStatus status, LiveConnectSession session, Object userState) {
                 mInitializeDialog.dismiss();
 
                 if (status == LiveStatus.CONNECTED) {


### PR DESCRIPTION
Changing the message that is shown to the user from a single toast pop-up
to a dialog that copies the link to the clipboard, as well as allowing for
navigating to the link directly.
